### PR TITLE
Prepare rabbitmq config for upgrade to 3.4, this config is backwards compatible for 2.8 clients

### DIFF
--- a/manifests/config/definitions.pp
+++ b/manifests/config/definitions.pp
@@ -8,7 +8,7 @@
 # Parameters:
 #  [rabbitmq_exchange] - name of the rabbitMQ exchange
 #  [rabbitmq_queue]    - name of hte rabbitMQ queue
-class rabbitmq::config::definitions($rabbitmq_exchange, $rabbitmq_queue) {
+class rabbitmq::config::definitions($rabbitmq_exchange = 'default_exchange', $rabbitmq_queue = 'default_exchange', $rabbitmq_remote_user = 'remote', $rabbitmq_remote_passwordhash = 'R5KfDHPjb45PISMNQZptoHaDYfA=') {
 
   $rabbitmq_definitions_json = '/etc/rabbitmq/rabbitmq_definitions.json'
 

--- a/manifests/config/definitions.pp
+++ b/manifests/config/definitions.pp
@@ -8,7 +8,7 @@
 # Parameters:
 #  [rabbitmq_exchange] - name of the rabbitMQ exchange
 #  [rabbitmq_queue]    - name of hte rabbitMQ queue
-class rabbitmq::config::definitions($rabbitmq_exchange = 'default_exchange', $rabbitmq_queue = 'default_exchange', $rabbitmq_remote_user = 'remote', $rabbitmq_remote_passwordhash = 'R5KfDH3Qk64C+8S5doDgp/R7E2w=') {
+class rabbitmq::config::definitions($rabbitmq_exchange = 'default_exchange', $rabbitmq_queue = 'default_queue', $rabbitmq_remote_user = 'remote', $rabbitmq_remote_passwordhash = 'R5KfDH3Qk64C+8S5doDgp/R7E2w=') {
 
   $rabbitmq_definitions_json = '/etc/rabbitmq/rabbitmq_definitions.json'
 

--- a/manifests/config/definitions.pp
+++ b/manifests/config/definitions.pp
@@ -8,7 +8,7 @@
 # Parameters:
 #  [rabbitmq_exchange] - name of the rabbitMQ exchange
 #  [rabbitmq_queue]    - name of hte rabbitMQ queue
-class rabbitmq::config::definitions($rabbitmq_exchange = 'default_exchange', $rabbitmq_queue = 'default_exchange', $rabbitmq_remote_user = 'remote', $rabbitmq_remote_passwordhash = 'R5KfDHPjb45PISMNQZptoHaDYfA=') {
+class rabbitmq::config::definitions($rabbitmq_exchange = 'default_exchange', $rabbitmq_queue = 'default_exchange', $rabbitmq_remote_user = 'remote', $rabbitmq_remote_passwordhash = 'R5KfDH3Qk64C+8S5doDgp/R7E2w=') {
 
   $rabbitmq_definitions_json = '/etc/rabbitmq/rabbitmq_definitions.json'
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -93,16 +93,16 @@ class rabbitmq::server (
   }
 
   file { $basedir:
-    ensure => directory,
-    owner  => 'rabbitmq',
-    group  => 'rabbitmq',
+    ensure  => directory,
+    owner   => 'rabbitmq',
+    group   => 'rabbitmq',
     require => Package[$package_name]
   }
 
   file { "${basedir}/mnesia":
-    ensure => directory,
-    owner  => 'rabbitmq',
-    group  => 'rabbitmq',
+    ensure  => directory,
+    owner   => 'rabbitmq',
+    group   => 'rabbitmq',
     require => Package[$package_name]
   }
 

--- a/templates/rabbitmq_config_definitions.json.erb
+++ b/templates/rabbitmq_config_definitions.json.erb
@@ -1,7 +1,7 @@
-{"rabbit_version":"2.8.7",
- "users":[{"name":"guest","password_hash":"R5KfDJonwz0h5XfDOqiX5IQrYiE=","tags":"administrator"}],
+{"rabbit_version":"3.4.3",
+ "users":[{"name":"guest","password_hash":"R5KfDJonwz0h5XfDOqiX5IQrYiE=","tags":"administrator"},{"name":"remote","password_hash":"R5KfDHPjb45PISMNQZptoHaDYfA=","tags":"administrator"}],
  "vhosts":[{"name":"/"}],
- "permissions":[{"user":"guest","vhost":"/","configure":".*","write":".*","read":".*"}],
+ "permissions":[{"user":"guest","vhost":"/","configure":".*","write":".*","read":".*"},{"user":"remote","vhost":"/","configure":".*","write":".*","read":".*"}],
  "queues":[{"name":"<%= @rabbitmq_queue %>","vhost":"/","durable":true,"auto_delete":false,"arguments":{}}],
  "exchanges":[{"name":"<%= @rabbitmq_exchange %>","vhost":"/","type":"direct","durable":true,"auto_delete":false,"internal":false,"arguments":{}}],
  "bindings":[{"source":"<%= @rabbitmq_exchange %>","vhost":"/","destination":"<%= @rabbitmq_queue %>","destination_type":"queue","routing_key":"","arguments":{}}]}

--- a/templates/rabbitmq_config_definitions.json.erb
+++ b/templates/rabbitmq_config_definitions.json.erb
@@ -1,5 +1,5 @@
 {"rabbit_version":"3.4.3",
- "users":[{"name":"guest","password_hash":"R5KfDJonwz0h5XfDOqiX5IQrYiE=","tags":"administrator"},{"name":"remote","password_hash":"R5KfDHPjb45PISMNQZptoHaDYfA=","tags":"administrator"}],
+ "users":[{"name":"guest","password_hash":"R5KfDJonwz0h5XfDOqiX5IQrYiE=","tags":"administrator"},{"name":"<%= @rabbitmq_remote_user -%>","password_hash":"<%= @rabbitmq_remote_passwordhash -%>","tags":"administrator"}],
  "vhosts":[{"name":"/"}],
  "permissions":[{"user":"guest","vhost":"/","configure":".*","write":".*","read":".*"},{"user":"remote","vhost":"/","configure":".*","write":".*","read":".*"}],
  "queues":[{"name":"<%= @rabbitmq_queue %>","vhost":"/","durable":true,"auto_delete":false,"arguments":{}}],

--- a/templates/rabbitmq_config_trailer.erb
+++ b/templates/rabbitmq_config_trailer.erb
@@ -1,3 +1,3 @@
-{rabbit, [{tcp_listeners, [<%= @port %>]}]}
+{rabbit, [{tcp_listeners, [<%= @port %>]},{loopback_users, []}]}
 ].
 % EOF


### PR DESCRIPTION
* Enable remote user 'remote' with default password remote
* Allow guest user to connect remotely during migration.